### PR TITLE
Update readme to have correct certgen filename

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -3,5 +3,5 @@
 To run this example, please make sure to generate the self signed cert first.
 
 ```bash
-bash gencert.bash
+bash certgen.bash
 ``` 


### PR DESCRIPTION
Hi, really awesome guide. The name of the bash file for cert generation just has switched places, this PR fixes it :)