### PR TITLE
chore(license): 🔧 add MIT license to the repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Percy Bolmér
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What?

This PR adds the MIT License in a `LICENSE` file to the repository with the current year and the repository owner's full name in the header of the file.

## Why?

It is a good idea to always license repositories so that other people and organizations can use your work without fear of the legal risk associated with making changes and distributing changes. The best and most recent example I can think of is the [`dust` DS emulator from the Rust ecosystem](https://www.reddit.com/r/rust/comments/14lamyg/please_add_licenses_to_your_projects_rust_ds/). This repository did not have a license associated with it, and so when it was unexpectedly deleted, none of the existing forks could be used to continue development. To minimize the legal risk of using code and examples from this repository, it would be very helpful if it had an open-source license.

I went to [your website](https://programmingpercy.tech/about/) to get your full name and place it in the author field of the license. If you would like your name to appear differently than `Percy Bolmér` in the license file, feel free to edit this PR.

I chose MIT because I feel it's the easiest to work with; out of all the licenses, it "stays out of the way" the best. If you would rather use a different license, feel free to make edits to this PR.

Lastly, I wanted to say thank you for [your informative video](https://www.youtube.com/watch?v=pKpKv9MKN-E) as it has helped me and my colleagues greatly get to understand the complexity of managing multiple WebSocket connections. Keep up the great work :smiley: